### PR TITLE
Modifié la logique des constructeurs, l'utilisateur entre désormais T…

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char* argv[])
 	
 	std::vector<double> cond{90, 110}; 
 	
-	model model_pde(100., 0.2, 0.05, 1, 1./10., 1./2., pp, cond);
+	model model_pde(100., 0.2, 0.05, 1, 10, 10, pp, cond);
 	
 	std::vector<double> r(10);
 	std::vector<double> sigma(10);
@@ -28,11 +28,11 @@ int main(int argc, char* argv[])
 		r[i]=i*3./100.;
 	}
 	
-	model model_pde_r(100., 0.2, r, 1, 1./10., 1./2., pp, cond);
+	model model_pde_r(100., 0.2, r, 1, 10, 10, pp, cond);
 
-	model model_pde_sigmar(100., sigma, r, 1, 1./10., 1./2., pp, cond);
+	model model_pde_sigmar(100., sigma, r, 1, 10, 10, pp, cond);
 
-	model model_pde_sigma(100., sigma, 0.05, 1, 1./10., 1./2., pp, cond);
+	model model_pde_sigma(100., sigma, 0.05, 1, 10, 10, pp, cond);
 	
 	solver_edp solver_model(model_pde);
 	
@@ -55,6 +55,15 @@ int main(int argc, char* argv[])
 	for(int i=0; i<test_inv.size();i++)
 	{
 		std::cout << test_inv[i] << ",";
+	}
+	
+	std::cout<< std::endl;
+	
+	std::vector<double> test_mul(solver_model.trig_matmul(mat, d));
+	
+	for(int i=0; i<test_inv.size();i++)
+	{
+		std::cout << test_mul[i] << ",";
 	}
 	
 	return 0;

--- a/model.cpp
+++ b/model.cpp
@@ -4,10 +4,10 @@
 #include <iostream>
 #include "model.hpp"
 
-model::model(const double& S0, const double& sigma, const double& r, const double& T, const double& dt, const double& dx, payoff& f, std::vector<double> conditions)
-	: m_dt(dt), m_T(T), m_f(f), m_initS(S0), m_dx(dx)
+model::model(const double& S0, const double& sigma, const double& r, const double& T, const int& n_t, const int& n_x, payoff& f, std::vector<double> conditions)
+	: m_nt(n_t), m_nx(n_x), m_T(T), m_f(f), m_initS(S0)
 	{
-		m_nt = std::round(T/dt);
+		m_dt = T/n_t;
 		
 		m_sigma.resize(m_nt);
 		
@@ -26,11 +26,12 @@ model::model(const double& S0, const double& sigma, const double& r, const doubl
 		m_cdt = get_conditions(conditions);
 	}
 	
-model::model(const double& S0, const std::vector<double>& sigma, const double& r, const double& T, const double& dt, const double& dx, payoff& f, std::vector<double> conditions)
-	: m_dt(dt), m_T(T), m_f(f), m_initS(S0), m_sigma(sigma), m_dx(dx)
+model::model(const double& S0, const std::vector<double>& sigma, const double& r, const double& T, const int& n_t, const int& n_x, payoff& f, std::vector<double> conditions)
+	: m_nt(n_t), m_nx(n_x), m_T(T), m_f(f), m_initS(S0), m_sigma(sigma)
 	{
-		m_nt = std::round(T/dt);
 		
+		m_dt = T/n_t;
+
 		m_r.resize(m_nt);
 		
 		for(int i=0;i<m_nt;++i)
@@ -41,11 +42,11 @@ model::model(const double& S0, const std::vector<double>& sigma, const double& r
 		m_cdt = get_conditions(conditions);
 	}
 
-model::model(const double& S0, const double& sigma, const std::vector<double>& r, const double& T, const double& dt, const double& dx, payoff& f, std::vector<double> conditions)
-	: m_r(r), m_dt(dt), m_T(T), m_f(f), m_initS(S0), m_dx(dx)
+model::model(const double& S0, const double& sigma, const std::vector<double>& r, const double& T, const int& n_t, const int& n_x, payoff& f, std::vector<double> conditions)
+	: m_r(r), m_nt(n_t), m_nx(n_x), m_T(T), m_f(f), m_initS(S0)
 	{	
 		
-		m_nt = std::round(T/dt);
+		m_dt = T/n_t;
 		
 		m_sigma.resize(m_nt);
 		
@@ -57,11 +58,11 @@ model::model(const double& S0, const double& sigma, const std::vector<double>& r
 		m_cdt = get_conditions(conditions);
 	}
 
-model::model(const double& S0, const std::vector<double>& sigma, const std::vector<double>& r, const double& T, const double& dt, const double& dx, payoff& f, std::vector<double> conditions)
-	: m_dt(dt), m_T(T), m_f(f), m_initS(S0), m_sigma(sigma), m_r(r), m_dx(dx)
+model::model(const double& S0, const std::vector<double>& sigma, const std::vector<double>& r, const double& T, const int& n_t, const int& n_x, payoff& f, std::vector<double> conditions)
+	: m_nt(n_t), m_nx(n_x), m_T(T), m_f(f), m_initS(S0), m_sigma(sigma), m_r(r)
 {
 	
-	m_nt = std::round(T/dt);
+	m_dt = T/n_t;
 		
 	m_cdt = get_conditions(conditions);
 }
@@ -127,7 +128,7 @@ std::vector<double> model::get_conditions(std::vector<double> conditions)
 	m_Smin = exp(log(m_initS) - 5 * get_vol(m_nt-1) * pow(m_T, 0.5));
 	m_Smax = exp(log(m_initS) + 5 * get_vol(m_nt-1) * pow(m_T, 0.5));
 	
-	m_nx = std::round((m_Smax - m_Smin)/m_dx);
+	m_dx = (m_Smax - m_Smin)/m_nx;
 	
 	std::vector<double> c = { 0, 9999999 };
 	if (std::equal(conditions.begin(), conditions.end(), c.begin()))

--- a/model.hpp
+++ b/model.hpp
@@ -5,10 +5,10 @@
 class model
 {
 public:
-	model(const double& S0, const double& sigma, const double& r, const double& T, const double& dt, const double& dx, payoff& f, std::vector<double> conditions);
-	model(const double& S0, const std::vector<double>& sigma, const double& r, const double& T, const double& dt, const double& dx, payoff& f, std::vector<double> conditions);
-	model(const double& S0, const double& sigma, const std::vector<double>& r, const double& T, const double& dt, const double& dx, payoff& f, std::vector<double> conditions);
-	model(const double& S0, const std::vector<double>& sigma, const std::vector<double>& r, const double& T, const double& dt, const double& dx, payoff& f, std::vector<double> conditions);
+	model(const double& S0, const double& sigma, const double& r, const double& T, const int& n_t, const int& n_x, payoff& f, std::vector<double> conditions);
+	model(const double& S0, const std::vector<double>& sigma, const double& r, const double& T, const int& n_t, const int& n_x, payoff& f, std::vector<double> conditions);
+	model(const double& S0, const double& sigma, const std::vector<double>& r, const double& T, const int& n_t, const int& n_x, payoff& f, std::vector<double> conditions);
+	model(const double& S0, const std::vector<double>& sigma, const std::vector<double>& r, const double& T, const int& n_t, const int& n_x, payoff& f, std::vector<double> conditions);
 
 	std::vector<std::vector<double>> pde_matrix(const int& i);
 	std::vector<std::vector<double>> pde_matrix_to_inverse(const int& i);

--- a/solver.cpp
+++ b/solver.cpp
@@ -47,13 +47,13 @@ std::vector<double> solver_edp::trig_matmul(const std::vector<std::vector<double
 	
 	std::vector<double> res(trig_mat[0]);
 	
-	for(int i=1;i<inf.size()-2;i++)
+	for(int i=1;i<inf.size()-1;i++)
 	{
 		res[i] = diag[i]*x[i] + inf[i]*x[i-1] + sup[i]*x[i+1];
 	}
 	
 	res[0] = diag[0]*x[0] + sup[0]*x[1];
-	res[res.size()-1] = diag[res.size()-1]*x[res.size()-1] + inf[res.size()-1]*x[res.size()-1];
+	res[res.size()-1] = diag[res.size()-1]*x[res.size()-1] + inf[res.size()-1]*x[res.size()-2];
 	
 	return res;
 }


### PR DESCRIPTION
… et le nombre de discrétisation en t et nb de discrétisation en x. Modif de la fct matmul qui était fausse et fonctionne maintenant correctement. A l'avenir matmul et inverse_product devront être passées en private. Elles sont public juste pour les tests actuels.