### PR TITLE
Modif des fonctions qui génèrent les matrices de PDE. Elles sont déso…

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -37,8 +37,6 @@ int main(int argc, char* argv[])
 	
 	std::vector<double> sol(solver_model.solve_pde());
 	
-	std::vector<std::vector<double>> mat(model_pde.pde_matrix_to_inverse(0));
-	
 	double dx = model_pde.get_dx();
 	double sMin = model_pde.getSmin();
 

--- a/model.cpp
+++ b/model.cpp
@@ -95,10 +95,8 @@ double model::get_dx()
 }
 
 
-std::vector<std::vector<double>> model::pde_matrix(const int& i)
+void model::pde_matrix(std::vector<std::vector<double>>& mat, const int& i)
 {	
-	std::vector<std::vector<double>> mat(3, std::vector<double>(m_nx));
-	
 	mat[1][0] = 1;
 	mat[1][m_nx-1] = 1;
 	
@@ -111,13 +109,11 @@ std::vector<std::vector<double>> model::pde_matrix(const int& i)
 		mat[0][j] = m_dt*(1-m_theta)/(2*m_dx)*(pow(sigma,2)/m_dx + pow(sigma,2)/2. - r);
 		mat[2][j] = m_dt*(1-m_theta)/(2*m_dx)*(pow(sigma,2)/m_dx - pow(sigma,2)/2. + r);
 	}
-	
-	return mat;
+
 }
 
-std::vector<std::vector<double>> model::pde_matrix_to_inverse(const int& i)
+void model::pde_matrix_to_inverse(std::vector<std::vector<double>>& mat, const int& i)
 {
-	std::vector<std::vector<double>> mat(3, std::vector<double>(m_nx));
 	
 	// Conditions initiales et terminales sur X :
 	
@@ -133,8 +129,7 @@ std::vector<std::vector<double>> model::pde_matrix_to_inverse(const int& i)
 		mat[0][j] = m_dt*m_theta/(2*m_dx)*(-pow(sigma,2)/m_dx - pow(sigma,2)/2. + r);
 		mat[2][j] = m_dt*m_theta/(2*m_dx)*(-pow(sigma,2)/m_dx + pow(sigma,2)/2. - r);
 	}
-	
-	return mat;
+
 }
 
 std::vector<double> model::getStrike()

--- a/model.hpp
+++ b/model.hpp
@@ -11,8 +11,8 @@ public:
 	model(const double& S0, const double& sigma, const std::vector<double>& r, const double& T, const int& n_t, const int& n_x, const double& theta, payoff& f, std::vector<std::vector<double>> conditions = {{0, 0}, {0,0}}, std::string method = "Dirichelet");
 	model(const double& S0, const std::vector<double>& sigma, const std::vector<double>& r, const double& T, const int& n_t, const int& n_x, const double& theta, payoff& f, std::vector<std::vector<double>> conditions = {{0, 0}, {0,0}}, std::string method = "Dirichelet");
 
-	std::vector<std::vector<double>> pde_matrix(const int& i);
-	std::vector<std::vector<double>> pde_matrix_to_inverse(const int& i);
+	void pde_matrix(std::vector<std::vector<double>>& mat, const int& i);
+	void pde_matrix_to_inverse(std::vector<std::vector<double>>& mat, const int& i);
 	std::vector<std::vector<double>> getDirichelet();
 	std::vector<std::vector<double>> getNeumann();
 	

--- a/solver.cpp
+++ b/solver.cpp
@@ -9,12 +9,14 @@ solver_edp::solver_edp(model pde_model)
 
 std::vector<double> solver_edp::solve_pde()
 {	
-	double tau = s_pde_model.m_T;
 	std::vector<std::vector<double>> boundaries(s_pde_model.m_cdt);
 	
 	std::vector<double> res(s_pde_model.m_nx);
 	res[0] = boundaries[0][s_pde_model.m_nt-1];
 	res[s_pde_model.m_nx-1] = boundaries[1][s_pde_model.m_nt-1];
+	
+	std::vector<std::vector<double>> pde_mat(3, std::vector<double>(s_pde_model.m_nx));
+	std::vector<std::vector<double>> pde_mat_inv(3, std::vector<double>(s_pde_model.m_nx));
 	
 	for(int i=1; i< res.size()-1; ++i)
 	{
@@ -23,7 +25,10 @@ std::vector<double> solver_edp::solve_pde()
 
 	for(int i = s_pde_model.m_nt - 1; i > 0; --i)
 	{
-		res = product_inverse(s_pde_model.pde_matrix_to_inverse(i), trig_matmul(s_pde_model.pde_matrix(i), res)); 
+		s_pde_model.pde_matrix_to_inverse(pde_mat_inv, i);
+		s_pde_model.pde_matrix(pde_mat, i);
+		
+		res = product_inverse(pde_mat_inv, trig_matmul(pde_mat, res)); 
 		
 		res[0] = boundaries[0][i-1];
 		res[s_pde_model.m_nx-1] = boundaries[1][i-1];
@@ -35,77 +40,40 @@ std::vector<double> solver_edp::solve_pde()
 std::vector<double> solver_edp::product_inverse(std::vector<std::vector<double>> trig_mat, std::vector<double> d)
 {
 	double w;
-	std::vector<double> a(trig_mat[0]);
-	std::vector<double> b(trig_mat[1]);
-	std::vector<double> c(trig_mat[2]);
 	
 	std::vector<double> x(trig_mat[0].size());
 	
 	for(int i=1; i< trig_mat[0].size(); ++i)
 	{
-		w = a[i]/b[i-1];
-		b[i] = b[i] - w*c[i-1];
+		w = trig_mat[0][i]/trig_mat[1][i-1];
+		trig_mat[1][i] = trig_mat[1][i] - w*trig_mat[2][i-1];
 		d[i] = d[i] - w*d[i-1];
 	}
 	
-	x[trig_mat[0].size()-1] = d[trig_mat[0].size()-1]/b[trig_mat[0].size()-1];
+	x[trig_mat[0].size()-1] = d[trig_mat[0].size()-1]/trig_mat[1][trig_mat[0].size()-1];
 	
 	for(int i=trig_mat[0].size()-2; i >= 0; --i)
 	{
-		x[i] = (d[i]-c[i]*x[i+1])/b[i];
+		x[i] = (d[i]-trig_mat[2][i]*x[i+1])/trig_mat[1][i];
 	}
 	
 	return x;
 }
 
-std::vector<double> solver_edp::trig_matmul(const std::vector<std::vector<double>>& trig_mat, const std::vector<double>& x)
+std::vector<double> solver_edp::trig_matmul(std::vector<std::vector<double>> trig_mat, std::vector<double> x)
 {
-	std::vector<double> inf(trig_mat[0]);
-	std::vector<double> diag(trig_mat[1]);
-	std::vector<double> sup(trig_mat[2]);
 	
 	std::vector<double> res(trig_mat[0].size());
 	
-	for(int i=1;i<inf.size()-1;i++)
+	for(int i=1;i<trig_mat[0].size()-1;i++)
 	{
-		res[i] = diag[i]*x[i] + inf[i]*x[i-1] + sup[i]*x[i+1];
+		res[i] = trig_mat[1][i]*x[i] + trig_mat[0][i]*x[i-1] + trig_mat[2][i]*x[i+1];
 	}
 	
-	res[0] = diag[0]*x[0] + sup[0]*x[1];
-	res[res.size()-1] = diag[res.size()-1]*x[res.size()-1] + inf[res.size()-1]*x[res.size()-2];
+	res[0] = trig_mat[1][0]*x[0] + trig_mat[2][0]*x[1];
+	res[res.size()-1] = trig_mat[1][res.size()-1]*x[res.size()-1] + trig_mat[0][res.size()-1]*x[res.size()-2];
 	
 	return res;
-}
-
-greeks::greeks(solver_edp rst_solver)
-	:m_solver(rst_solver)
-{
-	
-}
-
-std::vector<double> getDelta()
-{
-	return 
-}
-
-
-std::vector<double> getGamma()
-{
-	
-	return 
-}
-std::vector<double> getTheta()
-{
-	return 
-}
-
-std::vector<double> getVega()
-{
-	double bump = 0.01;
-	std::vector<double> bump_vol = m_solver.m_sigma + bump;
-	
-	model bumpvol_model = model(m_solver.m_initS, bump_vol, m_solver.m_r, m_solver.m_T, m_solver.m_nt, m_solver.m_nx, m_solver.m_theta, m_solver.m_f, m_solver.m_cdt, m_solver.m_method);
-	return 
 }
 
 

--- a/solver.hpp
+++ b/solver.hpp
@@ -11,24 +11,10 @@ public:
 	std::vector<double> solve_pde();
 	
 	std::vector<double> product_inverse(std::vector<std::vector<double>> trig_mat, std::vector<double> d);
-	std::vector<double> trig_matmul(const std::vector<std::vector<double>>& trig_mat, const std::vector<double>& x);
+	std::vector<double> trig_matmul(std::vector<std::vector<double>> trig_mat, std::vector<double> x);
 private:
 	model s_pde_model;
 	
 };
 
-
-class greeks
-{
-public:
-	greeks(solver_edp rst_solver);
-	
-	std::vector<double> getDelta();
-	std::vector<double> getGamma();
-	std::vector<double> getTheta();
-	std::vector<double> getVega();
-	
-private:
-	solver_edp m_solver;
-}
 #endif


### PR DESCRIPTION
…rmais en void et prennent en argument une matrice en ref, ce qui permet d'éviter de réallouer de la mémoire à chaque tour de boucle de solver